### PR TITLE
Fix purge issue

### DIFF
--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -4,32 +4,35 @@
     @case('success')
     @php
         $border = "border-green-400";
-        $bg = "bg-green-50";
-        $text = "green-800"
+        $icon = "text-green-400";
+        $background = "bg-green-50";
+        $text = "text-green-800"
     @endphp
     @break
     @case('warning')
     @php
         $border = "border-yellow-400";
-        $bg = "bg-yellow-50";
-        $text = "yellow-800"
+        $icon = "text-yellow-400"
+        $background = "bg-yellow-50";
+        $text = "text-yellow-800"
     @endphp
     @break
     @case('failure')
     @php
         $border = "border-red-400";
-        $bg = "bg-red-50";
-        $text = "red-800"
+        $icon = "text-red-400";
+        $background = "bg-red-50";
+        $text = "text-red-800"
     @endphp
     @break
 @endswitch
 
-<div {{ $attributes->merge(['class' => 'p-4 border-l-4']) }}
+<div {{ $attributes->merge(['class' => 'p-4 border-l-4' . $border, $background]) }}
         {{ $attributes->whereStartsWith('x-') }}
         {{ $attributes->thatStartWith('wire:') }}>
     <div class="flex">
         <div class="flex-shrink-0">
-            <svg class="w-5 h-5 text-{{$border}}" fill="currentColor" viewBox="0 0 20 20"
+            <svg class="w-5 h-5 {{ $icon }}" fill="currentColor" viewBox="0 0 20 20"
                  xmlns="http://www.w3.org/2000/svg">
                 @if($flag===true)
                     <path fill-rule="evenodd"
@@ -59,8 +62,8 @@
                 @endif
             </svg>
         </div>
-        <div class="ml-3 text-{{$text}}">
-            {{$slot}}
+        <div class="ml-3 {{ $text }}">
+            {{ $slot }}
         </div>
     </div>
 </div>

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -1,61 +1,61 @@
 @props(['type', 'flag' => false])
 
 @switch($type)
-@case('success')
-@php
-$border = "green-400";
-$bg = "green-50";
-$text = "green-800";
-@endphp
-@break
-@case('warning')
-@php
-$border = "yellow-400";
-$bg = "yellow-50";
-$text = "yellow-800";
-@endphp
-@break
-@case('failure')
-@php
-$border = "red-400";
-$bg = "red-50";
-$text = "red-800";
-@endphp
-@break
+    @case('success')
+    @php
+        $border = "green-400";
+        $bg = "green-50";
+        $text = "green-800"
+    @endphp
+    @break
+    @case('warning')
+    @php
+        $border = "yellow-400";
+        $bg = "yellow-50";
+        $text = "yellow-800"
+    @endphp
+    @break
+    @case('failure')
+    @php
+        $border = "red-400";
+        $bg = "red-50";
+        $text = "red-800"
+    @endphp
+    @break
 @endswitch
 
 <div {{ $attributes->merge(['class' => 'p-4 border-l-4 border-'.$border.' bg-'.$bg]) }}
-    {{ $attributes->whereStartsWith('x-') }}
-    {{ $attributes->thatStartWith('wire:') }}>
+        {{ $attributes->whereStartsWith('x-') }}
+        {{ $attributes->thatStartWith('wire:') }}>
     <div class="flex">
         <div class="flex-shrink-0">
             <svg class="w-5 h-5 text-{{$border}}" fill="currentColor" viewBox="0 0 20 20"
-                xmlns="http://www.w3.org/2000/svg">
+                 xmlns="http://www.w3.org/2000/svg">
                 @if($flag===true)
-                <path fill-rule="evenodd"
-                    d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z"
-                    clip-rule="evenodd"></path>
+                    <path fill-rule="evenodd"
+                          d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z"
+                          clip-rule="evenodd"></path>
                 @else
-                @switch($type)
-                @case('success')
-                <!-- Heroicon name: solid/check-circle -->
-                <path fill-rule="evenodd"
-                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                    clip-rule="evenodd" />
-                @break
-                @case('warning')
-                <!-- Heroicon name: solid/exclamation -->
-                <path fill-rule="evenodd"
-                    d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-                    clip-rule="evenodd" />
-                @break
-                @case('failure')
-                <!-- Heroicon name: solid/x-circle -->
-                <path fill-rule="evenodd"
-                    d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                    clip-rule="evenodd" />
-                @break
-                @endswitch
+                    @switch($type)
+                        @case('success')
+                    <!-- Heroicon name: solid/check-circle -->
+                        <path fill-rule="evenodd"
+                              d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                              clip-rule="evenodd"/>
+                        @break
+                        @case('warning')
+                    <!-- Heroicon name: solid/exclamation -->
+                        <path fill-rule="evenodd"
+                              d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                              clip-rule="evenodd"/>
+                        @break
+                        @case('failure')
+                    <!-- Heroicon name: solid/x-circle -->
+                        <path fill-rule="evenodd"
+                              d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                              clip-rule="evenodd"/>
+                        @break
+                    @endswitch
                 @endif
             </svg>
         </div>

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -3,28 +3,28 @@
 @switch($type)
     @case('success')
     @php
-        $border = "green-400";
-        $bg = "green-50";
+        $border = "border-green-400";
+        $bg = "bg-green-50";
         $text = "green-800"
     @endphp
     @break
     @case('warning')
     @php
-        $border = "yellow-400";
-        $bg = "yellow-50";
+        $border = "border-yellow-400";
+        $bg = "bg-yellow-50";
         $text = "yellow-800"
     @endphp
     @break
     @case('failure')
     @php
-        $border = "red-400";
-        $bg = "red-50";
+        $border = "border-red-400";
+        $bg = "bg-red-50";
         $text = "red-800"
     @endphp
     @break
 @endswitch
 
-<div {{ $attributes->merge(['class' => 'p-4 border-l-4 border-'.$border.' bg-'.$bg]) }}
+<div {{ $attributes->merge(['class' => 'p-4 border-l-4]) }}
         {{ $attributes->whereStartsWith('x-') }}
         {{ $attributes->thatStartWith('wire:') }}>
     <div class="flex">

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -24,7 +24,7 @@
     @break
 @endswitch
 
-<div {{ $attributes->merge(['class' => 'p-4 border-l-4]) }}
+<div {{ $attributes->merge(['class' => 'p-4 border-l-4']) }}
         {{ $attributes->whereStartsWith('x-') }}
         {{ $attributes->thatStartWith('wire:') }}>
     <div class="flex">

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -12,7 +12,7 @@
     @case('warning')
     @php
         $border = "border-yellow-400";
-        $icon = "text-yellow-400"
+        $icon = "text-yellow-400";
         $background = "bg-yellow-50";
         $text = "text-yellow-800"
     @endphp
@@ -27,7 +27,7 @@
     @break
 @endswitch
 
-<div {{ $attributes->merge(['class' => "p-4 border-l-4 . $border $background"]) }}
+<div {{ $attributes->merge(['class' => "p-4 border-l-4 $border $background"]) }}
         {{ $attributes->whereStartsWith('x-') }}
         {{ $attributes->thatStartWith('wire:') }}>
     <div class="flex">

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -27,7 +27,7 @@
     @break
 @endswitch
 
-<div {{ $attributes->merge(['class' => 'p-4 border-l-4' . $border, $background]) }}
+<div {{ $attributes->merge(['class' => "p-4 border-l-4 . $border $background"]) }}
         {{ $attributes->whereStartsWith('x-') }}
         {{ $attributes->thatStartWith('wire:') }}>
     <div class="flex">

--- a/resources/views/tests/alerts.blade.php
+++ b/resources/views/tests/alerts.blade.php
@@ -1,0 +1,1 @@
+<x-bcl::alert type="warning">This is a warning alert</x-bcl::alert>

--- a/tests/AlertsTest.php
+++ b/tests/AlertsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\Concerns\MakesHttpRequests;
+use NunoMaduro\LaravelMojito\InteractsWithViews;
+
+class AlertsTest extends TestCase
+{
+    use InteractsWithViews;
+    /** @test */
+    public function test_warning_alert()
+    {
+        $this->assertView('bcl::tests.alerts')->contains('This is a warning alert');
+
+    }
+}


### PR DESCRIPTION
@SarahSibert There was an issue with this component that might exist with other components (I haven't checked). Because we were using partially calculated class names like `text-{$color}` instead of the full class name like `text-yellow-800` the classes don't end up getting preserved by purgecss when running `npm run ...`. I've done a ton of this in various places and it's caused me tons of headaches. To solve it in the alert component, where I noticed it on my current project, I reworked it so that the variables hold full class names. This meant having to add a fourth variable to each alert style for the icon, since it was a variation on the text variable.

Another solution to the problem would be to simply make sure all the possible generated class names exist in full somewhere in the text of the template, even if it's in a comment. 

After you make sure this PR doesn't break anything you're working on and that I didn't make any catastrophic mistakes, go ahead and merge it in. Then as you're continuing to work on this and other projects, keep an eye out for similar situations and correct them as you encounter them.

Thank you!